### PR TITLE
Update 03_treasureHunterAtlas.html

### DIFF
--- a/tutorials/03_treasureHunterAtlas.html
+++ b/tutorials/03_treasureHunterAtlas.html
@@ -4,17 +4,18 @@
 <body>
 <p>
 <!-- Files needed to run Hexi -->
+<!--
 <script src="../src/modules/pixi.js/bin/pixi.js"></script>
 <script src="../bin/modules.js"></script>
 <script src="../bin/core.js"></script>
+-->
 
 <!--
 Preferably, just load the single hexi.js or hexi.min.js file
 which includes Pixi, the modules, and Hexi's core:
 -->
-<!--
+
 <script src="../bin/hexi.min.js"></script>
--->
 
 <!-- Main application file -->
 <script src="bin/treasureHunterAtlas.js"></script>


### PR DESCRIPTION
The original links leads to unexist files (before build). And the other four tutorial pages are all using the single built file which is already in the git repo. This update allows developers run the tutorials without building the whole library.
